### PR TITLE
[feat] 게시글 조회 페이지 api 연동

### DIFF
--- a/my-app/src/app/post/[slug]/page.tsx
+++ b/my-app/src/app/post/[slug]/page.tsx
@@ -185,7 +185,7 @@ const Post = ({ params }: { params: { slug: number } }) => {
               <p className="w-fit px-3 py-1 inline-block rounded-2xl font-semibold border-solid border-2 border-pink">
                 날짜
               </p>
-              <p className="inline-block ml-3 text-lg">{postData.date} {postData.startTime}</p>
+              <p className="inline-block ml-3 text-lg">{postData.date} {postData.startTime ? postData.startTime.slice(0, 5) : ''}</p>
             </div>
             <div className="mb-2">
               <p className="w-fit px-3 py-1 inline-block rounded-2xl font-semibold border-solid border-2 border-pink">
@@ -213,11 +213,14 @@ const Post = ({ params }: { params: { slug: number } }) => {
           </div>
         </div>
         <div className="flex items-center justify-center md:min-h-24 min-h-12">
-          <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickJoinButton}>지금 당장 참여하기 ({postData.currentPerson}/{postData.maxCapacity})</button>
-          <div>
-            <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickEditButton}>수정</button>
-            <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickDeleteButton}>삭제</button>
-          </div>
+          {
+            postData.editable ?
+            <div className="flex space-x-7">
+              <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 md:px-20 px-10 cursor-pointer" onClick={clickEditButton}>수정</button>
+              <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 md:px-20 px-10 cursor-pointer" onClick={clickDeleteButton}>삭제</button>
+            </div> :
+            <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickJoinButton}>지금 당장 참여하기 ({postData.currentPerson}/{postData.maxCapacity})</button>
+          }
         </div>
       </div>
       {showModal && <EditModalBox postData={postData} clickModal={clickEditButton} />}

--- a/my-app/src/app/post/[slug]/page.tsx
+++ b/my-app/src/app/post/[slug]/page.tsx
@@ -45,9 +45,24 @@ const Post = ({ params }: { params: { slug: number } }) => {
     return res.data;
   }
 
+  const joinChatRoom = async (id) => {
+    const res = await axios.post(`http://localhost:8000/api/v1/chatrooms/join`, {}, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      params: {
+        'boardId': id
+      }
+    });
+
+    return res.data;
+  }
+
   const getMutation = useMutation({
     mutationFn: getPostData, 
     onSuccess: (data) => {
+      console.log(data)
       setPostData(data);
       loadKakaoMap(data.location.latitude, data.location.longitude);
     },
@@ -67,6 +82,17 @@ const Post = ({ params }: { params: { slug: number } }) => {
     },
   });
 
+  const joinMutation = useMutation({
+    mutationFn: joinChatRoom, 
+    onSuccess: (data) => {
+      console.log(data);
+      //router.push(`/`);
+    },
+    onError: (error) => {
+      console.log(error.message);
+    },
+  });
+
   const clickEditButton = () => {
     setShowModal(!showModal)
   };
@@ -74,6 +100,10 @@ const Post = ({ params }: { params: { slug: number } }) => {
   const clickDeleteButton = () => {
     deleteMutation.mutate(params.slug);
   };
+
+  const clickJoinButton = () => {
+    joinMutation.mutate(params.slug);
+  }
 
   const loadKakaoMap = (latitude, longitude) => {
     // 카카오맵 api를 사용하기 위해 Head 부분에 script 태그 추가하기
@@ -183,7 +213,7 @@ const Post = ({ params }: { params: { slug: number } }) => {
           </div>
         </div>
         <div className="flex items-center justify-center md:min-h-24 min-h-12">
-          <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer">지금 당장 참여하기 ({postData.currentPerson}/{postData.maxCapacity})</button>
+          <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickJoinButton}>지금 당장 참여하기 ({postData.currentPerson}/{postData.maxCapacity})</button>
           <div>
             <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickEditButton}>수정</button>
             <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickDeleteButton}>삭제</button>

--- a/my-app/src/app/post/[slug]/page.tsx
+++ b/my-app/src/app/post/[slug]/page.tsx
@@ -65,6 +65,79 @@ const Post = ({ params }: { params: { slug: number } }) => {
     },
   });
 
+  // const clickEditButton = () => {
+  //   const container = document.getElementById("container");
+
+  //   container?.innerHTML = `
+  //     <div className="flex flex-col h-96 items-center justify-center">
+  //       <h1 className="text-darkpink font-semibold text-2xl">모집하기</h1>
+  //       <div className="flex flex-col items-center md:w-[30rem] w-[22rem] space-y-4 my-10">
+  //         <input type="text" id="title" placeholder="제목을 입력해주세요." className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm" />
+  //         <div className="flex md:flex-row flex-col justify-between w-full relative">
+  //           <DatePicker
+  //             showTimeInput
+  //             dateFormat='yyyy / MM / dd'
+  //             shouldCloseOnSelect
+  //             minDate={new Date()}
+  //             selected={selectedDate}
+  //             onChange={(date) => setSelectedDate(date)}
+  //             placeholderText="날짜를 선택해주세요."
+  //             className="placeholder:text-zinc-500 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm"
+  //             calendarClassName="bg-pink"
+  //           />
+  //           <div className='flex md:flex-row justify-between md:mt-0 mt-4'>
+  //             <input type='time' id='startTime' className='placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 md:w-36 w-2/3 md:absolute right-[7rem] px-4 py-2.5 font-semibold text-sm text-zinc-500 cursor-pointer'/>
+  //             <div className='relative'>
+  //               <div 
+  //                 className={`bg-white absolute border-solid rounded-[3px] h-50 right-0 z-10 max-w-[10rem] cursor-pointer w-24 px-4 py-2.5 font-semibold text-sm text-zinc-500
+  //                 ${view ? 'border-darkpink border-[2px]' : 'border-pink border-[1.5px]'}`}
+  //                 onClick={
+  //                   () => {
+  //                     setView(prev => !prev);
+  //                   }
+  //                 }
+  //               >
+  //                 {person === undefined ? '인원 선택' : `${person}명`}
+  //               </div>
+  //               <div id='personList' className="hidden absolute top-full z-[1000] overflow-auto h-56 bg-white border border-[1.5px] border-pink border-solid rounded-[3px] right-0 max-w-[10rem] w-24">
+  //                 <>
+  //                   {personItems.map((item, index) => (
+  //                     <div
+  //                       key={index} 
+  //                       onClick={
+  //                         () => {
+  //                           setView(prev => !prev);
+  //                           setPerson(item);                                   
+  //                         }
+  //                       } 
+  //                       className='person-item hidden hover:text-darkpink cursor-pointer w-full flex bg-white h-9 items-center justify-center py-2.5 font-semibold text-sm text-zinc-500'
+  //                     >
+  //                       {item}
+  //                     </div>
+  //                   ))}
+  //                 </>
+  //               </div>
+  //             </div>
+  //           </div>
+  //         </div>
+  //         <div className="flex justify-between w-full">
+  //           <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "보드게임" ? ' bg-pink ' : ' bg-white')} onClick={() => setCategory("보드게임")}>보드게임</div>
+  //           <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "카공" ? ' bg-pink' : ' bg-white')} onClick={() => setCategory("카공")}>카공</div>
+  //           <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "커피챗" ? ' bg-pink' : ' bg-white')} onClick={() => setCategory("커피챗")}>커피챗</div>
+  //           <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "기타" ? ' bg-pink' : ' bg-white')} onClick={() => setCategory("기타")}>기타</div>
+  //         </div>
+  //         <div className="relative md:w-[30rem] w-[22rem]">
+  //           <input type="text" name="location" id="location" placeholder="만날 장소를 입력해주세요." className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm"/>
+  //           <div id="result-list" className="hidden h-[18rem] bg-white border border-[1px] rounded-[3px] border-zinc-300 absolute top-full z-[100] w-full px-4 overflow-auto"></div>
+  //         </div>
+  //         <textarea id="description" placeholder="상세 내용을 입력해주세요." rows={12} className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-70 w-full px-4 py-2.5 font-semibold text-sm"></textarea>
+  //       </div>
+        
+  //       <button className="md:w-[30rem] w-[22rem] h-fit bg-darkpink text-md font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={createPost}>완료</button>  
+  //     </div>
+  //   `
+  // };
+
   const clickDeleteButton = () => {
     deleteMutation.mutate(params.slug);
   };
@@ -118,7 +191,7 @@ const Post = ({ params }: { params: { slug: number } }) => {
   }, []);
 
   return (
-    <div className="flex h-full max-w-full flex-col">
+    <div id="container" className="flex h-full max-w-full flex-col">
       <div className="relative w-full h-48">
         <Image src={BackgroundImage} alt="Background Image" fill priority />
       </div>
@@ -179,7 +252,7 @@ const Post = ({ params }: { params: { slug: number } }) => {
         <div className="flex items-center justify-center md:min-h-24 min-h-12">
           <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer">지금 당장 참여하기 ({postData.currentPerson}/{postData.maxCapacity})</button>
           <div>
-            <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer">수정</button>
+            <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" >수정</button>
             <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickDeleteButton}>삭제</button>
           </div>
         </div>

--- a/my-app/src/app/post/[slug]/page.tsx
+++ b/my-app/src/app/post/[slug]/page.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import BackgroundImage from "@/assets/post/background.png";
 import MegaphoneImage from "@/assets/post/megaphone.png";
 import token from "@/constants/loginToken";
+import EditModalBox from "@/components/EditModalBox";
 
 declare global {
   interface Window {
@@ -18,6 +19,7 @@ declare global {
 const Post = ({ params }: { params: { slug: number } }) => {
   const [locationAddress, setLocationAddress] = useState<String>("");
   const [postData, setPostData] = useState<Object>({});
+  const [showModal, setShowModal] = useState(false)
   
   const router = useRouter();
 
@@ -65,78 +67,9 @@ const Post = ({ params }: { params: { slug: number } }) => {
     },
   });
 
-  // const clickEditButton = () => {
-  //   const container = document.getElementById("container");
-
-  //   container?.innerHTML = `
-  //     <div className="flex flex-col h-96 items-center justify-center">
-  //       <h1 className="text-darkpink font-semibold text-2xl">모집하기</h1>
-  //       <div className="flex flex-col items-center md:w-[30rem] w-[22rem] space-y-4 my-10">
-  //         <input type="text" id="title" placeholder="제목을 입력해주세요." className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm" />
-  //         <div className="flex md:flex-row flex-col justify-between w-full relative">
-  //           <DatePicker
-  //             showTimeInput
-  //             dateFormat='yyyy / MM / dd'
-  //             shouldCloseOnSelect
-  //             minDate={new Date()}
-  //             selected={selectedDate}
-  //             onChange={(date) => setSelectedDate(date)}
-  //             placeholderText="날짜를 선택해주세요."
-  //             className="placeholder:text-zinc-500 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm"
-  //             calendarClassName="bg-pink"
-  //           />
-  //           <div className='flex md:flex-row justify-between md:mt-0 mt-4'>
-  //             <input type='time' id='startTime' className='placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 md:w-36 w-2/3 md:absolute right-[7rem] px-4 py-2.5 font-semibold text-sm text-zinc-500 cursor-pointer'/>
-  //             <div className='relative'>
-  //               <div 
-  //                 className={`bg-white absolute border-solid rounded-[3px] h-50 right-0 z-10 max-w-[10rem] cursor-pointer w-24 px-4 py-2.5 font-semibold text-sm text-zinc-500
-  //                 ${view ? 'border-darkpink border-[2px]' : 'border-pink border-[1.5px]'}`}
-  //                 onClick={
-  //                   () => {
-  //                     setView(prev => !prev);
-  //                   }
-  //                 }
-  //               >
-  //                 {person === undefined ? '인원 선택' : `${person}명`}
-  //               </div>
-  //               <div id='personList' className="hidden absolute top-full z-[1000] overflow-auto h-56 bg-white border border-[1.5px] border-pink border-solid rounded-[3px] right-0 max-w-[10rem] w-24">
-  //                 <>
-  //                   {personItems.map((item, index) => (
-  //                     <div
-  //                       key={index} 
-  //                       onClick={
-  //                         () => {
-  //                           setView(prev => !prev);
-  //                           setPerson(item);                                   
-  //                         }
-  //                       } 
-  //                       className='person-item hidden hover:text-darkpink cursor-pointer w-full flex bg-white h-9 items-center justify-center py-2.5 font-semibold text-sm text-zinc-500'
-  //                     >
-  //                       {item}
-  //                     </div>
-  //                   ))}
-  //                 </>
-  //               </div>
-  //             </div>
-  //           </div>
-  //         </div>
-  //         <div className="flex justify-between w-full">
-  //           <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "보드게임" ? ' bg-pink ' : ' bg-white')} onClick={() => setCategory("보드게임")}>보드게임</div>
-  //           <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "카공" ? ' bg-pink' : ' bg-white')} onClick={() => setCategory("카공")}>카공</div>
-  //           <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "커피챗" ? ' bg-pink' : ' bg-white')} onClick={() => setCategory("커피챗")}>커피챗</div>
-  //           <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "기타" ? ' bg-pink' : ' bg-white')} onClick={() => setCategory("기타")}>기타</div>
-  //         </div>
-  //         <div className="relative md:w-[30rem] w-[22rem]">
-  //           <input type="text" name="location" id="location" placeholder="만날 장소를 입력해주세요." className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm"/>
-  //           <div id="result-list" className="hidden h-[18rem] bg-white border border-[1px] rounded-[3px] border-zinc-300 absolute top-full z-[100] w-full px-4 overflow-auto"></div>
-  //         </div>
-  //         <textarea id="description" placeholder="상세 내용을 입력해주세요." rows={12} className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-70 w-full px-4 py-2.5 font-semibold text-sm"></textarea>
-  //       </div>
-        
-  //       <button className="md:w-[30rem] w-[22rem] h-fit bg-darkpink text-md font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={createPost}>완료</button>  
-  //     </div>
-  //   `
-  // };
+  const clickEditButton = () => {
+    setShowModal(!showModal)
+  };
 
   const clickDeleteButton = () => {
     deleteMutation.mutate(params.slug);
@@ -252,12 +185,14 @@ const Post = ({ params }: { params: { slug: number } }) => {
         <div className="flex items-center justify-center md:min-h-24 min-h-12">
           <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer">지금 당장 참여하기 ({postData.currentPerson}/{postData.maxCapacity})</button>
           <div>
-            <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" >수정</button>
+            <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickEditButton}>수정</button>
             <button className="h-fit bg-darkpink text-lg font-semibold text-white rounded-lg py-2 px-20 cursor-pointer" onClick={clickDeleteButton}>삭제</button>
           </div>
         </div>
       </div>
+      {showModal && <EditModalBox postData={postData} clickModal={clickEditButton} />}
     </div>
+    
   );
 };
 

--- a/my-app/src/app/write/page.tsx
+++ b/my-app/src/app/write/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
+import token from "@/constants/loginToken";
 
 declare global {
   interface Window {
@@ -38,7 +39,7 @@ const Write = () => {
     mutationFn: async (newPost) => {
       const res = await axios.post('http://localhost:8000/api/v1/boards', newPost, {
         headers: {
-          'Authorization': `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMDI3NjEzNywiZXhwIjoxNzIwMjc5NzM3fQ.5-aUhnF9XsEsR8ZQybf_S8hn1OF66kzWJAAcI6Td654`,
+          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
       });

--- a/my-app/src/app/write/page.tsx
+++ b/my-app/src/app/write/page.tsx
@@ -20,7 +20,6 @@ const Write = () => {
   const [person, setPerson] = useState<number>();
   const [category, setCategory] = useState<String>();
   const personItems = Array.from({ length: 15 }, (_, index) => index + 1);
-  const [value, onChange] = useState('10:00');  
   const [lat, setLat] = useState<number>(0);
   const [lng, setLng] = useState<number>(0);
 
@@ -58,8 +57,7 @@ const Write = () => {
     const title = document.getElementById('title');
     const description = document.getElementById('description');
     const locationName = document.getElementById('location');
-
-    
+    const startTime = document.getElementById('startTime');
 
     const request = {
       "title": title.value,
@@ -72,7 +70,7 @@ const Write = () => {
       "locationName": locationName.value,
       "maxCapacity": person,
       "date": `${selectedDate.getFullYear()}-${selectedDate.getMonth() < 10 ? '0' : ''}${selectedDate.getMonth()}-${selectedDate.getDate() < 10 ? '0' : ''}${selectedDate.getDate()}`,
-      "startTime": value
+      "startTime": startTime.value
     };
 
     mutation.mutate(request);
@@ -192,7 +190,7 @@ const Write = () => {
             calendarClassName="bg-pink"
           />
           <div className='flex md:flex-row justify-between md:mt-0 mt-4'>
-            <input type='time' className='placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 md:w-36 w-2/3 md:absolute right-[7rem] px-4 py-2.5 font-semibold text-sm text-zinc-500 cursor-pointer'/>
+            <input type='time' id='startTime' className='placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 md:w-36 w-2/3 md:absolute right-[7rem] px-4 py-2.5 font-semibold text-sm text-zinc-500 cursor-pointer'/>
             <div className='relative'>
               <div 
                 className={`bg-white absolute border-solid rounded-[3px] h-50 right-0 z-10 max-w-[10rem] cursor-pointer w-24 px-4 py-2.5 font-semibold text-sm text-zinc-500

--- a/my-app/src/app/write/page.tsx
+++ b/my-app/src/app/write/page.tsx
@@ -58,7 +58,7 @@ const Write = () => {
     const description = document.getElementById('description');
     const locationName = document.getElementById('location');
     const startTime = document.getElementById('startTime');
-    console.log(selectedDate.getDate())
+    
     const request = {
       "title": title.value,
       "category": category,

--- a/my-app/src/app/write/page.tsx
+++ b/my-app/src/app/write/page.tsx
@@ -58,7 +58,7 @@ const Write = () => {
     const description = document.getElementById('description');
     const locationName = document.getElementById('location');
     const startTime = document.getElementById('startTime');
-
+    console.log(selectedDate.getDate())
     const request = {
       "title": title.value,
       "category": category,
@@ -69,10 +69,11 @@ const Write = () => {
       },
       "locationName": locationName.value,
       "maxCapacity": person,
-      "date": `${selectedDate.getFullYear()}-${selectedDate.getMonth() < 10 ? '0' : ''}${selectedDate.getMonth()}-${selectedDate.getDate() < 10 ? '0' : ''}${selectedDate.getDate()}`,
+      "date": `${selectedDate.getFullYear()}-${selectedDate.getMonth()+1 < 10 ? '0' : ''}${selectedDate.getMonth()+1}-${selectedDate.getDate() < 10 ? '0' : ''}${selectedDate.getDate()}`,
       "startTime": startTime.value
     };
 
+    console.log(request)
     mutation.mutate(request);
     
   }

--- a/my-app/src/assets/post/closeOff.svg
+++ b/my-app/src/assets/post/closeOff.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="100" height="110" viewBox="0,0,300,150"
+style="fill:#f9476b;">
+<g fill="#f9476b" fill-rule="nonzero" stroke="none" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="none" font-weight="none" font-size="none" text-anchor="none" style="mix-blend-mode: normal"><g transform="scale(10.66667,10.66667)"><path d="M12,2c-5.511,0 -10,4.489 -10,10c0,5.511 4.489,10 10,10c5.511,0 10,-4.489 10,-10c0,-5.511 -4.489,-10 -10,-10zM12,4c4.43012,0 8,3.56988 8,8c0,4.43012 -3.56988,8 -8,8c-4.43012,0 -8,-3.56988 -8,-8c0,-4.43012 3.56988,-8 8,-8zM8.70703,7.29297l-1.41406,1.41406l3.29297,3.29297l-3.29297,3.29297l1.41406,1.41406l3.29297,-3.29297l3.29297,3.29297l1.41406,-1.41406l-3.29297,-3.29297l3.29297,-3.29297l-1.41406,-1.41406l-3.29297,3.29297z"></path></g></g>
+</svg>

--- a/my-app/src/assets/post/closeOn.svg
+++ b/my-app/src/assets/post/closeOn.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="100" height="110" viewBox="0,0,300,150"
+style="fill:#f9476b;">
+<g fill="#f9476b" fill-rule="nonzero" stroke="none" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="10" stroke-dasharray="" stroke-dashoffset="0" font-family="none" font-weight="none" font-size="none" text-anchor="none" style="mix-blend-mode: normal"><g transform="scale(10.66667,10.66667)"><path d="M12,2c-5.53,0 -10,4.47 -10,10c0,5.53 4.47,10 10,10c5.53,0 10,-4.47 10,-10c0,-5.53 -4.47,-10 -10,-10zM17,15.59l-1.41,1.41l-3.59,-3.59l-3.59,3.59l-1.41,-1.41l3.59,-3.59l-3.59,-3.59l1.41,-1.41l3.59,3.59l3.59,-3.59l1.41,1.41l-3.59,3.59z"></path></g></g>
+</svg>

--- a/my-app/src/components/EditModalBox.tsx
+++ b/my-app/src/components/EditModalBox.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import CloseOnIcon from "@/assets/post/closeOn.svg";
+import CloseOffIcon from "@/assets/post/closeOff.svg";
+import token from "@/constants/loginToken";
+import Image from "next/image";
+import EditModalBoxProps from '@/types/EditModalBoxProps';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+};
+// {
+//   "id": 1,
+//   "title": "보드게임 할 사람?",
+//   "maxCapacity": 4,
+//   "description": "string",
+//   "startTime": null,
+//   "date": "2024-05-20",
+//   "category": "보드게임",
+//   "location": {
+//     "latitude": 33.33,
+//     "longitude": 22.22,
+//     "locationName": "소정이네 집"
+//   },
+// }
+const EditModalBox = ({postData, clickModal}) : EditModalBoxProps => {
+  const [selectedDate, setSelectedDate] = useState<Date | null>(postData.date);
+  const [view, setView] = useState(false); 
+  const [person, setPerson] = useState<number>(postData.maxCapacity);
+  const [category, setCategory] = useState<String>(postData.category);
+  const personItems = Array.from({ length: 15 }, (_, index) => index + 1);
+  const [lat, setLat] = useState<number>(postData.location?.latitude);
+  const [lng, setLng] = useState<number>(postData.location?.longitude);
+  const [isHovered, setIsHovered] = useState(false);
+
+  // 자식 노드를 모두 삭제하는 함수
+  function removeAllResultItems(parent, child) {
+    if (parent) {
+      const resultItems = parent.getElementsByClassName(child);
+      while (resultItems.length > 0) {
+        resultItems[0].remove();
+      }
+    }
+  }
+
+  useEffect(() => {
+    // 카카오맵 api를 사용하기 위해 Head 부분에 script 태그 추가하기
+    const kakaoMapScript = document.createElement('script');
+    kakaoMapScript.async = false;
+    kakaoMapScript.type = "text/javascript";
+    kakaoMapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=4b5f228cb3b8bf6903521cc0f6f67769&autoload=false&libraries=services`;
+    document.head.appendChild(kakaoMapScript);
+
+    const onLoadKakaoAPI = () => {
+      window.kakao.maps.load(() => {
+        // 장소 검색 서비스를 초기화합니다.
+        const ps = new window.kakao.maps.services.Places();
+        const keywordInput = document.getElementById('location') as HTMLInputElement;
+        const resultList = document.getElementById('result-list') as HTMLElement;
+
+        // 키워드 입력 이벤트 리스너
+        keywordInput.addEventListener('keyup', function() {
+          const keyword = keywordInput.value;
+
+          if (!keyword.trim()) {
+            resultList.innerHTML = '';
+            resultList.classList.remove('h-18rem]','bg-white', 'border', 'border-[1px]', 'rounded-[3px]', 'border-zinc-300');
+            return;
+          }
+
+          ps.keywordSearch(keyword, function(data: any[], status: string) {
+            if (status === window.kakao.maps.services.Status.OK) {
+              displayPlaces(data);
+            } else {
+              resultList.innerHTML = '<div class="result-item mt-2">검색 결과가 없습니다.</div>';
+              resultList.classList.add('h-[18rem]', 'bg-white', 'border', 'border-[1px]', 'rounded-[3px]', 'border-zinc-300');
+            }
+          });
+        });
+
+        // 장소 검색 결과를 리스트로 표시하는 함수
+        function displayPlaces(places: any[]) {
+          resultList.innerHTML = '';
+
+          places.forEach(function(place) {
+            const listItem = document.createElement('div');
+            listItem.className = 'result-item h-16 flex flex-col justify-center';
+            
+            const placeName = document.createElement('p');
+            placeName.innerText = place.place_name;
+            placeName.className = 'font-semibold';
+
+            const placeAddress = document.createElement('p');
+            placeAddress.innerText = place.address_name;
+            placeAddress.className = 'text-zinc-500 text-sm';
+
+            listItem.appendChild(placeName);
+            listItem.appendChild(placeAddress);
+
+            listItem.onclick = function() {
+              resultList.classList.add('hidden');
+              
+              keywordInput.value = place.place_name;
+              
+              setLng(place.x);
+              setLat(place.y);
+              
+              removeAllResultItems(resultList, 'result-item');
+            };
+
+            resultList.appendChild(listItem);
+          });
+
+          resultList.classList.remove('hidden');
+        };
+      });
+    };
+
+    kakaoMapScript.addEventListener('load', onLoadKakaoAPI);
+  }, []);
+
+  return (
+    <div className="flex justify-center items-center w-full h-full bg-neutral-500/50 fixed top-0 left-0" onClick={clickModal}>
+      <div className="flex flex-col relative md:w-[33rem] w-[25rem] h-[45rem] items-center justify-center bg-white rounded-[10px] px-8 py-6" onClick={(e) => e.stopPropagation()}>
+        <div 
+          className="flex absolute top-3 right-4 cursor-pointer"
+          onClick={clickModal}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <Image
+            src={isHovered ? CloseOnIcon : CloseOffIcon}
+            alt="Close Off Icon"
+            width={35}
+            height={40}
+            priority
+          />
+        </div>
+        <h1 className="text-darkpink font-semibold text-2xl">수정하기</h1>
+        <div className="flex flex-col items-center md:w-[30rem] w-[22rem] space-y-4 my-10">
+          <input type="text" id="title" placeholder="제목을 입력해주세요." defaultValue={postData.title} className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm" />
+          <div className="flex md:flex-row flex-col justify-between w-full relative">
+            <DatePicker
+              showTimeInput
+              dateFormat='yyyy / MM / dd'
+              shouldCloseOnSelect
+              minDate={new Date()}
+              selected={selectedDate}
+              onChange={(date) => setSelectedDate(date)}
+              placeholderText="날짜를 선택해주세요."
+              className="placeholder:text-zinc-500 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm"
+              calendarClassName="bg-pink"
+            />
+            <div className='flex md:flex-row justify-between md:mt-0 mt-4'>
+              <input type='time' id='startTime' defaultValue={postData.startTime} className='placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 md:w-36 w-2/3 md:absolute right-[7rem] px-4 py-2.5 font-semibold text-sm text-zinc-500 cursor-pointer'/>
+              <div className='relative'>
+                <div 
+                  className={`bg-white absolute border-solid rounded-[3px] h-50 right-0 z-10 max-w-[10rem] cursor-pointer w-24 px-4 py-2.5 font-semibold text-sm text-zinc-500
+                  ${view ? 'border-darkpink border-[2px]' : 'border-pink border-[1.5px]'}`}
+                  onClick={
+                    () => {
+                      setView(prev => !prev);
+                    }
+                  }
+                >
+                  {person === undefined ? '인원 선택' : `${person}명`}
+                </div>
+                <div id='personList' className="hidden absolute top-full z-[1000] overflow-auto h-56 bg-white border border-[1.5px] border-pink border-solid rounded-[3px] right-0 max-w-[10rem] w-24">
+                  <>
+                    {personItems.map((item, index) => (
+                      <div
+                        key={index} 
+                        onClick={
+                          () => {
+                            setView(prev => !prev);
+                            setPerson(item);                                   
+                          }
+                        } 
+                        className='person-item hidden hover:text-darkpink cursor-pointer w-full flex bg-white h-9 items-center justify-center py-2.5 font-semibold text-sm text-zinc-500'
+                      >
+                        {item}
+                      </div>
+                    ))}
+                  </>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="flex justify-between w-full">
+            <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "보드게임" ? ' bg-pink ' : ' bg-white')} onClick={() => setCategory("보드게임")}>보드게임</div>
+            <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "카공" ? ' bg-pink' : ' bg-white')} onClick={() => setCategory("카공")}>카공</div>
+            <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "커피챗" ? ' bg-pink' : ' bg-white')} onClick={() => setCategory("커피챗")}>커피챗</div>
+            <div className={"border-[1.5px] border-solid border-pink rounded-2xl text-center md:w-28 w-20 py-1.5 text-sm text-zinc-500 font-semibold cursor-pointer" + (category === "기타" ? ' bg-pink' : ' bg-white')} onClick={() => setCategory("기타")}>기타</div>
+          </div>
+          <div className="relative md:w-[30rem] w-[22rem]">
+            <input type="text" name="location" id="location" placeholder="만날 장소를 입력해주세요." defaultValue={postData.location.locationName} className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm"/>
+            <div id="result-list" className="hidden h-[18rem] bg-white border border-[1px] rounded-[3px] border-zinc-300 absolute top-full z-[100] w-full px-4 overflow-auto"></div>
+          </div>
+          <textarea id="description" placeholder="상세 내용을 입력해주세요." defaultValue={postData.description} rows={12} className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-70 w-full px-4 py-2.5 font-semibold text-sm"></textarea>
+        </div>    
+        <button className="md:w-[30rem] w-[22rem] h-fit bg-darkpink text-md font-semibold text-white rounded-lg py-2 px-20 cursor-pointer">완료</button>  
+      </div>
+    </div>
+  );
+};
+
+export default EditModalBox;

--- a/my-app/src/constants/loginToken.ts
+++ b/my-app/src/constants/loginToken.ts
@@ -1,0 +1,3 @@
+const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMDI4MDAxNywiZXhwIjoxNzIwMjgzNjE3fQ.r_1Xm5Ef6XGYHwk3lNeKiPupEaSEPTq4QbOOXeIvs9E";
+
+export default token;

--- a/my-app/src/constants/loginToken.ts
+++ b/my-app/src/constants/loginToken.ts
@@ -1,3 +1,3 @@
-const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMDI4MDAxNywiZXhwIjoxNzIwMjgzNjE3fQ.r_1Xm5Ef6XGYHwk3lNeKiPupEaSEPTq4QbOOXeIvs9E";
+const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMDUyNzk3NCwiZXhwIjoxNzIwNTMxNTc0fQ.mix5d86Cc4JA3HbHw4UZO_Ub5bBo-qevoaDllTJSzWM";
 
 export default token;

--- a/my-app/src/constants/loginToken.ts
+++ b/my-app/src/constants/loginToken.ts
@@ -1,2 +1,2 @@
-const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMTA2ODIyOCwiZXhwIjoxNzIxMDcxODI4fQ.6TMc4T6XRu5d2w2N-KfAfiiG182rwoxTOXMbvGhn9X4";
+const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjIsImlhdCI6MTcyMTQwMjU1OSwiZXhwIjoxNzIxNDA2MTU5fQ.Iw2VgIH7kQx5eGsTVRwj9binAG3JDrys1-lOMV09Bow";
 export default token;

--- a/my-app/src/constants/loginToken.ts
+++ b/my-app/src/constants/loginToken.ts
@@ -1,2 +1,2 @@
-const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMTA2MzIyMywiZXhwIjoxNzIxMDY2ODIzfQ.aDSSDipuugSDZhb2_cpH9i9drFQ1fPKEN_0IiVAtz_g";
+const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMTA2ODIyOCwiZXhwIjoxNzIxMDcxODI4fQ.6TMc4T6XRu5d2w2N-KfAfiiG182rwoxTOXMbvGhn9X4";
 export default token;

--- a/my-app/src/constants/loginToken.ts
+++ b/my-app/src/constants/loginToken.ts
@@ -1,3 +1,2 @@
-const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMDUyNzk3NCwiZXhwIjoxNzIwNTMxNTc0fQ.mix5d86Cc4JA3HbHw4UZO_Ub5bBo-qevoaDllTJSzWM";
-
+const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMDUzMjY1NCwiZXhwIjoxNzIwNTM2MjU0fQ.2vDMafkS18d2d9BaPFIUe6waX6dDHq433FT3LjzpqNQ";
 export default token;

--- a/my-app/src/constants/loginToken.ts
+++ b/my-app/src/constants/loginToken.ts
@@ -1,2 +1,2 @@
-const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMDUzMjY1NCwiZXhwIjoxNzIwNTM2MjU0fQ.2vDMafkS18d2d9BaPFIUe6waX6dDHq433FT3LjzpqNQ";
+const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMTA2MzIyMywiZXhwIjoxNzIxMDY2ODIzfQ.aDSSDipuugSDZhb2_cpH9i9drFQ1fPKEN_0IiVAtz_g";
 export default token;

--- a/my-app/src/constants/loginToken.ts
+++ b/my-app/src/constants/loginToken.ts
@@ -1,2 +1,2 @@
-const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjIsImlhdCI6MTcyMTQwMjU1OSwiZXhwIjoxNzIxNDA2MTU5fQ.Iw2VgIH7kQx5eGsTVRwj9binAG3JDrys1-lOMV09Bow";
+const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImlhdCI6MTcyMTQwNTA5MSwiZXhwIjoxNzIxNDA4NjkxfQ.w1C4f9g2hd-_osViXgdWVY6-cMVFKQIiKZIa1cPUoSA";
 export default token;

--- a/my-app/src/types/EditModalBoxProps.ts
+++ b/my-app/src/types/EditModalBoxProps.ts
@@ -1,0 +1,31 @@
+type postData = {
+  "id": number,
+  "title": string,
+  "maxCapacity": number,
+  "currentPerson": number,
+  "description": string,
+  "startTime": null,
+  "date": string,
+  "category": string,
+  "user": {
+    "userId": number,
+    "username": string
+  },
+  "location": {
+    "id": number,
+    "latitude": number,
+    "longitude": number,
+    "locationName": string
+  },
+  "createdAt": string,
+  "updatedAt": string,
+  "deletedAt": null,
+  "status": string
+};
+
+type editModalBoxProps = {
+  postData: postData,
+  clickModal: () => void
+};
+
+export default editModalBoxProps;


### PR DESCRIPTION
### 작업 내용
- [x] 단일 게시글 조회 api 연동
- [x] 게시글 수정 api 연동
- [x] 게시글 삭제 api 연동
- [ ] sse 연동
- [x] 게시글의 채팅방 접속 api 연동
- [x] 게시글 작성한 유저일 경우 참여하기 버튼 대신 수정/삭제 뜨도록 퍼블리싱
- [x] 게시글 수정 모달창 퍼블리싱

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/1adc27fa-8bb1-4b0a-8a93-2dbfd67015d6">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c819dd4c-cc4b-45b3-a316-443b7aa0103f">


### 추후 이어서 작업할 것

- sse 연동
- 단일 게시글 조회 api 연동 useMutation -> useQuery로 리팩토링
- 게시글 수정 api 호출 후 낙관적 업데이트 적용하기
- 채팅방 구현 완료 시 채팅방 접속 api 호출 이후 라우팅 되도록
