### PR TITLE
[refactor] 단일 게시글 조회 및 게시글 생성 페이지 리팩토링

### DIFF
--- a/my-app/.gitignore
+++ b/my-app/.gitignore
@@ -26,7 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
+.env
 
 # vercel
 .vercel

--- a/my-app/src/app/boards/page.tsx
+++ b/my-app/src/app/boards/page.tsx
@@ -52,7 +52,7 @@ const Boards = () => {
 
   const posts = data?.data || [];
   const totalPage = data?.totalPage || 0;
-
+  console.log(posts)
   useEffect(() => {
     console.log("Loading:", isLoading);
     console.log("Data:", posts);

--- a/my-app/src/app/post/[slug]/page.tsx
+++ b/my-app/src/app/post/[slug]/page.tsx
@@ -78,12 +78,11 @@ const Post = ({ params }: { params: { slug: number } }) => {
   const joinMutation = useMutation({
     mutationFn: joinChatRoom,
     onSuccess: data => {
-      // console.log(data);
-      //router.push(`/`);
+      router.push(`/chat/${data.chatRoomId}`);
     },
     onError: error => {
       console.log(error.message);
-    },
+    }
   });
 
   const clickEditButton = () => {

--- a/my-app/src/app/post/[slug]/page.tsx
+++ b/my-app/src/app/post/[slug]/page.tsx
@@ -53,17 +53,17 @@ const Post = ({ params }: { params: { slug: number } }) => {
 
   
 
-  const getMutation = useMutation({
-    mutationFn: getPostData,
-    onSuccess: data => {
-      setPostData(data);
-      setCurrentPerson(data.currentCapacity);
-      loadKakaoMap(data.location.latitude, data.location.longitude);
-    },
-    onError: error => {
-      console.log(error.message);
-    },
-  });
+  // const getMutation = useMutation({
+  //   mutationFn: getPostData,
+  //   onSuccess: data => {
+  //     setPostData(data);
+  //     setCurrentPerson(data.currentCapacity);
+  //     loadKakaoMap(data.location.latitude, data.location.longitude);
+  //   },
+  //   onError: error => {
+  //     console.log(error.message);
+  //   },
+  // });
 
   const deleteMutation = useMutation({
     mutationFn: deletePostData,
@@ -160,7 +160,7 @@ const Post = ({ params }: { params: { slug: number } }) => {
 
   useEffect(() => {
     if (isSuccess && postData) {
-      setCurrentPerson(postData.currentCapacity);
+      setCurrentPerson(postData.currentPerson);
       loadKakaoMap(postData.location.latitude, postData.location.longitude);
     }
   }, [isSuccess, postData]);

--- a/my-app/src/app/post/[slug]/page.tsx
+++ b/my-app/src/app/post/[slug]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import axios from "axios";
+import api from "@/utils/api";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import BackgroundImage from "@/assets/post/background.png";
@@ -15,7 +15,7 @@ declare global {
   }
 }
 const getPostData = async id => {
-  const res = await axios.get(`http://localhost:8000/api/v1/boards/${id}`, 
+  const res = await api.get(`/api/v1/boards/${id}`, 
     { withCredentials: true }
   );
   console.log(res.data)
@@ -33,8 +33,8 @@ const Post = ({ params }: { params: { slug: number } }) => {
   
 
   const deletePostData = async id => {
-    const res = await axios.delete(
-      `http://localhost:8000/api/v1/boards/${id}`,
+    const res = await api.delete(
+      `/api/v1/boards/${id}`,
       { withCredentials: true }
     );
 
@@ -42,8 +42,8 @@ const Post = ({ params }: { params: { slug: number } }) => {
   };
 
   const joinChatRoom = async id => {
-    const res = await axios.post(
-      `http://localhost:8000/api/v1/chatrooms/join/${id}`,
+    const res = await api.post(
+      `/api/v1/chatrooms/join/${id}`,
       {},
       { withCredentials: true }
     );

--- a/my-app/src/app/write/page.tsx
+++ b/my-app/src/app/write/page.tsx
@@ -136,19 +136,20 @@ const Write = () => {
           }
 
           ps.keywordSearch(keyword, function (data: any[], status: string) {
+            resultList.classList.add(
+              "h-[18rem]",
+              "bg-white",
+              "border",
+              "border-[1px]",
+              "rounded-[3px]",
+              "border-zinc-300",
+            );
+
             if (status === window.kakao.maps.services.Status.OK) {
               displayPlaces(data);
             } else {
               resultList.innerHTML =
                 '<div class="result-item mt-2">검색 결과가 없습니다.</div>';
-              resultList.classList.add(
-                "h-[18rem]",
-                "bg-white",
-                "border",
-                "border-[1px]",
-                "rounded-[3px]",
-                "border-zinc-300",
-              );
             }
           });
         });
@@ -206,9 +207,9 @@ const Write = () => {
         />
         <div className="flex md:flex-row flex-col justify-between w-full relative">
           <DatePicker
-            showTimeInput
             dateFormat="yyyy / MM / dd"
             shouldCloseOnSelect
+            withPortal
             minDate={new Date()}
             selected={selectedDate}
             onChange={date => setSelectedDate(date)}

--- a/my-app/src/app/write/page.tsx
+++ b/my-app/src/app/write/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import axios from "axios";
+import api from "@/utils/api";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
@@ -35,7 +35,7 @@ const Write = () => {
   }
   const mutation = useMutation({
     mutationFn: async (newPost) => {
-      const res = await axios.post('http://localhost:8000/api/v1/boards', 
+      const res = await api.post('/api/v1/boards', 
         newPost, 
         {
           withCredentials: true,

--- a/my-app/src/app/write/page.tsx
+++ b/my-app/src/app/write/page.tsx
@@ -18,7 +18,7 @@ const Write = () => {
   const [view, setView] = useState(false);
   const [person, setPerson] = useState<number>();
   const [category, setCategory] = useState<String>();
-  const personItems = Array.from({ length: 15 }, (_, index) => index + 1);
+  const personItems = Array.from({ length: 14 }, (_, index) => index + 2);
   const [lat, setLat] = useState<number>(0);
   const [lng, setLng] = useState<number>(0);
 

--- a/my-app/src/components/EditModalBox.tsx
+++ b/my-app/src/components/EditModalBox.tsx
@@ -111,6 +111,9 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
   }, [view]);
 
   useEffect(() => {
+    const calendarHeader = document.getElementsByClassName("react-datepicker__header ");
+    console.log(calendarHeader);
+    // calendarHeader[0].classList.add("bg-pink");
 
     const kakaoMapScript = document.createElement("script");
     kakaoMapScript.async = false;
@@ -136,7 +139,7 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
           if (!keyword.trim()) {
             resultList.innerHTML = "";
             resultList.classList.remove(
-              "h-18rem]",
+              "h-[18rem]",
               "bg-white",
               "border",
               "border-[1px]",
@@ -147,19 +150,20 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
           }
 
           ps.keywordSearch(keyword, function (data: any[], status: string) {
+            resultList.classList.add(
+              "h-[18rem]",
+              "bg-white",
+              "border",
+              "border-[1px]",
+              "rounded-[3px]",
+              "border-zinc-300",
+            );
+
             if (status === window.kakao.maps.services.Status.OK) {
               displayPlaces(data);
             } else {
               resultList.innerHTML =
                 '<div class="result-item mt-2">검색 결과가 없습니다.</div>';
-              resultList.classList.add(
-                "h-[18rem]",
-                "bg-white",
-                "border",
-                "border-[1px]",
-                "rounded-[3px]",
-                "border-zinc-300",
-              );
             }
           });
         });
@@ -170,7 +174,7 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
           places.forEach(function (place) {
             const listItem = document.createElement("div");
             listItem.className =
-              "result-item h-16 flex flex-col justify-center";
+              "result-item h-16 bg-white flex flex-col justify-center";
 
             const placeName = document.createElement("p");
             placeName.innerText = place.place_name;
@@ -211,7 +215,7 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
       onClick={clickModal}
     >
       <div
-        className="flex flex-col relative md:w-[33rem] w-[25rem] h-[45rem] items-center justify-center bg-white rounded-[10px] px-8 py-6"
+        className="flex flex-col relative md:w-[33rem] w-[23rem] h-[40rem] items-center justify-center bg-white rounded-[10px] px-8 py-6"
         onClick={e => e.stopPropagation()}
       >
         <div
@@ -228,8 +232,8 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
             priority
           />
         </div>
-        <h1 className="text-darkpink font-semibold text-2xl">수정하기</h1>
-        <div className="flex flex-col items-center md:w-[30rem] w-[22rem] space-y-4 my-10">
+        <h1 className="text-darkpink font-semibold text-2xl pt-5">수정하기</h1>
+        <div className="flex flex-col items-center md:w-[30rem] w-[20rem] space-y-4 my-5">
           <input
             type="text"
             id="title"
@@ -238,17 +242,18 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
             className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm"
           />
           <div className="flex md:flex-row flex-col justify-between w-full relative">
-            <DatePicker
-              showTimeInput
-              dateFormat="yyyy / MM / dd"
-              shouldCloseOnSelect
-              minDate={new Date()}
-              selected={selectedDate}
-              onChange={date => setSelectedDate(date)}
-              placeholderText="날짜를 선택해주세요."
-              className="placeholder:text-zinc-500 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm"
-              calendarClassName="bg-pink"
-            />
+          <DatePicker
+            dateFormat="yyyy / MM / dd"
+            shouldCloseOnSelect
+            minDate={new Date()}
+            selected={selectedDate}
+            onChange={date => setSelectedDate(date)}
+            placeholderText="날짜를 선택해주세요."
+            className="placeholder:text-zinc-500 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] z-30 h-11 w-full px-4 py-2.5 font-semibold text-sm"
+            calendarClassName="bg-pink"
+            withPortal
+          />
+            
             <div className="flex md:flex-row justify-between md:mt-0 mt-4">
               <input
                 type="time"
@@ -258,7 +263,7 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
               />
               <div className="relative">
                 <div
-                  className={`bg-white absolute border-solid rounded-[3px] h-50 right-0 z-10 max-w-[10rem] cursor-pointer w-24 px-4 py-2.5 font-semibold text-sm text-zinc-500
+                  className={`bg-white absolute border-solid rounded-[3px] h-50 right-0 max-w-[10rem] cursor-pointer w-24 px-4 py-2.5 font-semibold text-sm text-zinc-500
                   ${
                     view
                       ? "border-darkpink border-[2px]"
@@ -272,7 +277,7 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
                 </div>
                 <div
                   id="personList"
-                  className="hidden absolute top-full z-[1000] overflow-auto h-56 bg-white border border-[1.5px] border-pink border-solid rounded-[3px] right-0 max-w-[10rem] w-24"
+                  className="hidden absolute top-full z-20 overflow-auto h-56 bg-white border border-[1.5px] border-pink border-solid rounded-[3px] right-0 max-w-[10rem] w-24"
                 >
                   <>
                     {personItems.map((item, index) => (
@@ -337,7 +342,7 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
               id="location"
               placeholder="만날 장소를 입력해주세요."
               defaultValue={postData.location.locationName}
-              className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] h-11 w-full px-4 py-2.5 font-semibold text-sm"
+              className="placeholder:text-zinc-500 text-slate-800 border-[1.5px] border-solid border-pink outline-darkpink rounded-[3px] z-10 h-11 w-full px-4 py-2.5 font-semibold text-sm"
             />
             <div
               id="result-list"

--- a/my-app/src/components/EditModalBox.tsx
+++ b/my-app/src/components/EditModalBox.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useMutation } from "@tanstack/react-query";
-import axios from "axios";
+import api from "@/utils/api";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import CloseOnIcon from "@/assets/post/closeOn.svg";
@@ -30,7 +30,7 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
 
   const mutation = useMutation({
     mutationFn: async (editedPost) => {
-      const res = await axios.patch(`http://localhost:8000/api/v1/boards/${postData.id}`,
+      const res = await api.patch(`/api/v1/boards/${postData.id}`,
         editedPost, 
         {
           withCredentials: true,
@@ -44,7 +44,7 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
     },
     onSuccess: data => {
       clickModal();
-      //location.reload();
+      location.reload();
     },
     onError: error => {
       console.log(error.message);

--- a/my-app/src/components/EditModalBox.tsx
+++ b/my-app/src/components/EditModalBox.tsx
@@ -23,7 +23,7 @@ const EditModalBox = ({ postData, clickModal }): EditModalBoxProps => {
   const [view, setView] = useState(false);
   const [person, setPerson] = useState<number>(postData.maxCapacity);
   const [category, setCategory] = useState<String>(postData.category);
-  const personItems = Array.from({ length: 15 }, (_, index) => index + 1);
+  const personItems = Array.from({ length: 14 }, (_, index) => index + 2);
   const [lat, setLat] = useState<number>(postData.location?.latitude);
   const [lng, setLng] = useState<number>(postData.location?.longitude);
   const [isHovered, setIsHovered] = useState(false);


### PR DESCRIPTION
## 작업한 내용

### 공통

- api 호출 시 baseURL은 api.ts의 api 함수를 이용해 작성되도록 코드 수정

### 게시글 생성 페이지

- 인원 선택 최솟값 1에서 2로 수정
- 약간의 디자인 수정 및 퍼블리싱 오류 수정

### 단일 게시글 조회 페이지

- 게시글 조회 api 호출 방식 useMutation -> useQuery로 변경
- 참여하기 버튼 클릭 시 채팅 페이지로 라우팅 연결
- api 호출 response 값에서 사용하는 필드명 수정